### PR TITLE
Preview / Liveview from Device Webcam

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -6,6 +6,7 @@ $config['dev'] = true;
 $config['use_print'] = true;
 $config['use_qr'] = true;
 $config['show_fork'] = true;
+$config['file_format'] = null;
 #$config['file_format'] = 'date'; // comment in to get dateformat images
 
 // FOLDERS

--- a/index.php
+++ b/index.php
@@ -35,6 +35,7 @@ require_once('db.php');
 
 		<!-- Loader -->
 		<div class="stages" id="loader">
+            <video id="video" autoplay></video>
 			<div class="loaderInner">
 			<div class="spinner">
 				<i class="fa fa-cog fa-spin"></i>

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -241,11 +241,17 @@ h3 {
 .loaderInner {
   position: absolute;
   left: 50%;
-  margin-left: -250px;
-  height: 200px;
   width: 500px;
   top: 50%;
-  margin-top: -100px; }
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.5);
+  padding: 15px; }
+
+#video {
+  position: absolute;
+  top: 50%;
+  margin-top: -240px;
+  margin-left: -360px; }
 
 .homebtn {
   position: absolute;

--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -13,7 +13,15 @@ var photoBooth = (function () {
         gallery = $('#gallery'),
         processing = false,
         pswp = {},
-        resultPage = $('#result');
+        resultPage = $('#result'),
+        webcamConstraints = {
+            audio: false,
+            video: {
+                width: 720,
+                height: 480,
+                facingMode: "user",
+            }
+        };
 
     // timeOut function
     public.resetTimeOut = function () {
@@ -206,6 +214,16 @@ var photoBooth = (function () {
         } else {
             if (!processing) {
                 public.reset();
+
+                navigator.mediaDevices.getUserMedia(webcamConstraints)
+                    .then(function(stream) {
+                        var video = document.getElementById('video');
+                        video.srcObject = stream;
+                    })
+                    .catch(function (error) {
+                        console.log(error);
+                    });
+
                 loader.slideDown('slow', 'easeOutBounce', function () {
                     public.countdown(countDown, $('#counter'));
                 });

--- a/resources/sass/style.scss
+++ b/resources/sass/style.scss
@@ -304,11 +304,18 @@ h3 {
 .loaderInner {
   position: absolute;
   left: 50%;
-  margin-left: -250px;
-  height: 200px;
   width: 500px;
   top: 50%;
-  margin-top: -100px;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.5);
+  padding: 15px;
+}
+
+#video {
+  position: absolute;
+  top: 50%;
+  margin-top: -240px;
+  margin-left: -360px;
 }
 
 .homebtn {


### PR DESCRIPTION
Hey,

I added some Code to show a preview / liveview while the countdown is running.

It uses the Camera from the device (tablet) so it might not be the same aperture/color/field of view as the "real" camera used. So this is just a simple solution to see if you have 🍰 on your face 😉

With the same technique it could also be added as a background like in #20 
It could also be adapted to the ideas in #14  (small screen on the start page, enable/disable in setting) the tablet tends to get pretty hot after some time though also the battery drains fast.

In Chrome the site has to be loaded over https in order to work. Firefox seems to work without it.
In both browsers you have to allow the access of the camera obviously... 