### PR TITLE
trigger key: only take collage if collage is enabled

### DIFF
--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -546,7 +546,14 @@ const photoBooth = (function () {
         }
 
         if (config.collage_key && parseInt(config.collage_key, 10) === ev.keyCode) {
-            public.thrill('collage');
+            if (config.use_collage) {
+                public.thrill('collage');
+            } else {
+                if (config.dev) {
+                    console.log('Collage key pressed. Please enable collage in your config. Triggering photo now.');
+                }
+                public.thrill('photo');
+            }
         }
     });
 


### PR DESCRIPTION

Respect `use_collage` config.

Current behaviour:
Collage is disabled but collage key defined -> press collage key -> collage starts

With this change:
Collage is disabled but collage key defined -> press collage key -> photo starts

I've thought about doing nothing besides logging if collage is disabled but collage key defined and pressed, but don't make it complicated and take a picture instead.

