### PR TITLE
admin: add simple login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ resources/css/admin.css
 resources/css/style.css
 /archives/
 resources/css/rounded.css
+resources/css/login.css

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,7 +1,28 @@
 <?php
+session_start();
 
 require_once('../lib/config.php');
 require_once('../lib/configsetup.inc.php');
+
+// LOGIN
+$username = $config['login_username'];
+$password = $config['login_password'];
+$random1 = $config['login_random1'];
+$hash = md5($random1.$username);
+$error = false;
+if (isset($_POST['submit'])) {
+    if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && $_POST['password'] == $password) {
+        //IF USERNAME AND PASSWORD ARE CORRECT SET THE LOG-IN SESSION
+        $_SESSION["login"] = $hash;
+        header("Location: $_SERVER[PHP_SELF]");
+        exit;
+    } else {
+        // DISPLAY FORM WITH ERROR
+        $error = true;
+    }
+}
+// END LOGIN
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -32,6 +53,7 @@ require_once('../lib/configsetup.inc.php');
 <div id="wrapper" class="adminbg" style="overflow-y: auto;">
 	<div class="admin-panel">
 		<h2><a class="back-to-pb" href="../">Photobooth</a></h2>
+		<?php if( !$config['login_enabled'] || (isset($_SESSION['login']) && $_SESSION['login'] == $hash)): ?>
 		<button class="reset-btn">
 			<span class="save">
 				<span data-l10n="reset"></span>
@@ -120,6 +142,18 @@ require_once('../lib/configsetup.inc.php');
 					<span data-l10n="saveerror"></span>
 				</span>
 			</button>
+		<?php else: ?>
+		<form method='post' class="login">
+			<label for="username"><span data-l10n="login_username"></span></label>
+			<input type="text" name="username" id="username">
+			<label for="password"><span data-l10n="login_password"></span></label>
+			<input type="password" name="password" id="password">
+			<input type="submit" name="submit" value="submit">
+			<?php if ($error !== false) {
+				echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
+			} ?>
+		</form>
+		<?php endif; ?>
 		</div>
 	</div>
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -13,8 +13,6 @@ if (isset($_POST['submit'])) {
     if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && password_verify($_POST["password"], $hashed_password)) {
         //IF USERNAME AND PASSWORD ARE CORRECT SET THE LOG-IN SESSION
         $_SESSION['auth'] = true;
-        header("Location: $_SERVER[PHP_SELF]");
-        exit;
     } else {
         // DISPLAY FORM WITH ERROR
         $error = true;

--- a/admin/index.php
+++ b/admin/index.php
@@ -34,7 +34,7 @@ require_once('../lib/configsetup.inc.php');
 <div id="wrapper" class="adminbg" style="overflow-y: auto;">
 	<div class="admin-panel">
 		<h2><a class="back-to-pb" href="../">Photobooth</a></h2>
-		<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true && $config['protect_admin'])): ?>
+		<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect_admin']): ?>
 		<button class="reset-btn">
 			<span class="save">
 				<span data-l10n="reset"></span>

--- a/admin/index.php
+++ b/admin/index.php
@@ -8,8 +8,10 @@ require_once('../lib/configsetup.inc.php');
 $username = $config['login_username'];
 $password = $config['login_password'];
 $error = false;
+$hashed_password = password_hash($password, PASSWORD_DEFAULT);
+
 if (isset($_POST['submit'])) {
-    if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && $_POST['password'] == $password) {
+    if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && password_verify($_POST["password"], $hashed_password)) {
         //IF USERNAME AND PASSWORD ARE CORRECT SET THE LOG-IN SESSION
         $_SESSION['auth'] = true;
         header("Location: $_SERVER[PHP_SELF]");
@@ -143,9 +145,9 @@ if (isset($_POST['submit'])) {
 		<?php else: ?>
 		<form method='post' class="login">
 			<label for="username"><span data-l10n="login_username"></span></label>
-			<input type="text" name="username" id="username">
+			<input type="text" name="username" id="username" autocomplete="on">
 			<label for="password"><span data-l10n="login_password"></span></label>
-			<input type="password" name="password" id="password">
+			<input type="password" name="password" id="password" autocomplete="on">
 			<input type="submit" name="submit" value="submit">
 			<?php if ($error !== false) {
 				echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';

--- a/admin/index.php
+++ b/admin/index.php
@@ -52,9 +52,15 @@ require_once('../lib/configsetup.inc.php');
 				<span data-l10n="saveerror"></span>
 			</span>
 		</button>
+
+		<?php if($_SESSION['auth'] === true): ?>
+		<p><a href="../logout.php" class="btn btn--tiny btn--flex fa fa-sign-out"><span data-l10n="logout"></span></a></p>
+		<?php endif; ?>
+
 		<div id="checkVersion">
 			<p><a href="#" class="btn btn--tiny btn--flex"><span data-l10n="check_version"></span></a></p>
 		</div>
+
 		<div class="accordion">
 			<form>
 				<?php

--- a/admin/index.php
+++ b/admin/index.php
@@ -7,13 +7,11 @@ require_once('../lib/configsetup.inc.php');
 // LOGIN
 $username = $config['login_username'];
 $password = $config['login_password'];
-$random1 = $config['login_random1'];
-$hash = md5($random1.$username);
 $error = false;
 if (isset($_POST['submit'])) {
     if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && $_POST['password'] == $password) {
         //IF USERNAME AND PASSWORD ARE CORRECT SET THE LOG-IN SESSION
-        $_SESSION["login"] = $hash;
+        $_SESSION['auth'] = true;
         header("Location: $_SERVER[PHP_SELF]");
         exit;
     } else {
@@ -53,7 +51,7 @@ if (isset($_POST['submit'])) {
 <div id="wrapper" class="adminbg" style="overflow-y: auto;">
 	<div class="admin-panel">
 		<h2><a class="back-to-pb" href="../">Photobooth</a></h2>
-		<?php if( !$config['login_enabled'] || (isset($_SESSION['login']) && $_SESSION['login'] == $hash)): ?>
+		<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
 		<button class="reset-btn">
 			<span class="save">
 				<span data-l10n="reset"></span>

--- a/admin/index.php
+++ b/admin/index.php
@@ -34,7 +34,7 @@ require_once('../lib/configsetup.inc.php');
 <div id="wrapper" class="adminbg" style="overflow-y: auto;">
 	<div class="admin-panel">
 		<h2><a class="back-to-pb" href="../">Photobooth</a></h2>
-		<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
+		<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true && $config['protect_admin'])): ?>
 		<button class="reset-btn">
 			<span class="save">
 				<span data-l10n="reset"></span>

--- a/admin/index.php
+++ b/admin/index.php
@@ -4,22 +4,6 @@ session_start();
 require_once('../lib/config.php');
 require_once('../lib/configsetup.inc.php');
 
-// LOGIN
-$username = $config['login_username'];
-$hashed_password = $config['login_password'];
-$error = false;
-
-if (isset($_POST['submit'])) {
-    if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && password_verify($_POST["password"], $hashed_password)) {
-        //IF USERNAME AND PASSWORD ARE CORRECT SET THE LOG-IN SESSION
-        $_SESSION['auth'] = true;
-    } else {
-        // DISPLAY FORM WITH ERROR
-        $error = true;
-    }
-}
-// END LOGIN
-
 ?>
 <!DOCTYPE html>
 <html>
@@ -139,18 +123,10 @@ if (isset($_POST['submit'])) {
 					<span data-l10n="saveerror"></span>
 				</span>
 			</button>
-		<?php else: ?>
-		<form method='post' class="login">
-			<label for="username"><span data-l10n="login_username"></span></label>
-			<input type="text" name="username" id="username" autocomplete="on">
-			<label for="password"><span data-l10n="login_password"></span></label>
-			<input type="password" name="password" id="password" autocomplete="on">
-			<input type="submit" name="submit" value="submit">
-			<?php if ($error !== false) {
-				echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
-			} ?>
-		</form>
-		<?php endif; ?>
+		<?php else:
+		header("location: ../login.php");
+		exit;
+		endif; ?>
 		</div>
 	</div>
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -6,9 +6,8 @@ require_once('../lib/configsetup.inc.php');
 
 // LOGIN
 $username = $config['login_username'];
-$password = $config['login_password'];
+$hashed_password = $config['login_password'];
 $error = false;
-$hashed_password = password_hash($password, PASSWORD_DEFAULT);
 
 if (isset($_POST['submit'])) {
     if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && password_verify($_POST["password"], $hashed_password)) {

--- a/admin/index.php
+++ b/admin/index.php
@@ -53,7 +53,7 @@ require_once('../lib/configsetup.inc.php');
 			</span>
 		</button>
 
-		<?php if($_SESSION['auth'] === true): ?>
+		<?php if(isset($_SESSION['auth']) && $_SESSION['auth'] === true): ?>
 		<p><a href="../logout.php" class="btn btn--tiny btn--flex fa fa-sign-out"><span data-l10n="logout"></span></a></p>
 		<?php endif; ?>
 

--- a/api/admin.php
+++ b/api/admin.php
@@ -81,9 +81,13 @@ if ($data['type'] == 'config') {
         }
     }
 
-    if (!($newConfig['login_password'] === $config['login_password'])) {
-        $hashing = password_hash($newConfig['login_password'], PASSWORD_DEFAULT);
-        $newConfig['login_password'] = $hashing;
+    if (isset($newConfig['login_password']) && !empty($newConfig['login_password'])) {
+        if (!($newConfig['login_password'] === $config['login_password'])) {
+            $hashing = password_hash($newConfig['login_password'], PASSWORD_DEFAULT);
+            $newConfig['login_password'] = $hashing;
+        }
+    } else {
+        $newConfig['login_enabled'] = false;
     }
 
     $content = "<?php\n\$config = ". var_export(arrayRecursiveDiff($newConfig, $defaultConfig), true) . ";";

--- a/api/admin.php
+++ b/api/admin.php
@@ -81,6 +81,11 @@ if ($data['type'] == 'config') {
         }
     }
 
+    if (!($newConfig['login_password'] === $config['login_password'])) {
+        $hashing = password_hash($newConfig['login_password'], PASSWORD_DEFAULT);
+        $newConfig['login_password'] = $hashing;
+    }
+
     $content = "<?php\n\$config = ". var_export(arrayRecursiveDiff($newConfig, $defaultConfig), true) . ";";
 
     if (file_put_contents($my_config_file, $content)) {

--- a/api/admin.php
+++ b/api/admin.php
@@ -81,13 +81,17 @@ if ($data['type'] == 'config') {
         }
     }
 
-    if (isset($newConfig['login_password']) && !empty($newConfig['login_password'])) {
-        if (!($newConfig['login_password'] === $config['login_password'])) {
-            $hashing = password_hash($newConfig['login_password'], PASSWORD_DEFAULT);
-            $newConfig['login_password'] = $hashing;
+    if ($newConfig['login_enabled']) {
+        if (isset($newConfig['login_password']) && !empty($newConfig['login_password'])) {
+            if (!($newConfig['login_password'] === $config['login_password'])) {
+                $hashing = password_hash($newConfig['login_password'], PASSWORD_DEFAULT);
+                $newConfig['login_password'] = $hashing;
+            }
+        } else {
+            $newConfig['login_enabled'] = false;
         }
     } else {
-        $newConfig['login_enabled'] = false;
+        $newConfig['login_password'] = NULL;
     }
 
     $content = "<?php\n\$config = ". var_export(arrayRecursiveDiff($newConfig, $defaultConfig), true) . ";";

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -74,7 +74,7 @@ $config['event']['symbol'] = 'fa-heart-o';
 // LOGIN
 $config['login_enabled'] = false;
 $config['login_username'] = 'Photo';
-$config['login_password'] = 'booth';
+$config['login_password'] = NULL;
 
 // GALLERY
 // should the gallery list the newest pictures first?

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -75,7 +75,6 @@ $config['event']['symbol'] = 'fa-heart-o';
 $config['login_enabled'] = false;
 $config['login_username'] = 'Photo';
 $config['login_password'] = 'booth';
-$config['login_random1'] = 'Q4KbXus?G'; // hash for login
 
 // GALLERY
 // should the gallery list the newest pictures first?

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -71,6 +71,12 @@ $config['event']['textLeft'] = 'Name 1';
 $config['event']['textRight'] = 'Name 2';
 $config['event']['symbol'] = 'fa-heart-o';
 
+// LOGIN
+$config['login_enabled'] = false;
+$config['login_username'] = 'Photo';
+$config['login_password'] = 'booth';
+$config['login_random1'] = 'Q4KbXus?G'; // hash for login
+
 // GALLERY
 // should the gallery list the newest pictures first?
 $config['show_gallery'] = true;

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -75,6 +75,8 @@ $config['event']['symbol'] = 'fa-heart-o';
 $config['login_enabled'] = false;
 $config['login_username'] = 'Photo';
 $config['login_password'] = NULL;
+$config['protect_admin'] = true;
+$config['protect_index'] = false;
 
 // GALLERY
 // should the gallery list the newest pictures first?

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 
 require_once('lib/config.php');
 require_once('lib/db.php');
@@ -41,7 +42,7 @@ $imagelist = ($config['newest_first'] === true) ? array_reverse($images) : $imag
 
 <body class="deselect">
 	<div id="wrapper">
-
+	<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true || !$config['protect_index'])): ?>
 		<!-- Start Page -->
 		<div class="stages" id="start">
 			<?php if ($config['show_gallery']): ?>
@@ -210,6 +211,10 @@ $imagelist = ($config['newest_first'] === true) ? array_reverse($images) : $imag
 		<div style="position:absolute; bottom:0; right:0;">
 			<img src="resources/img/spacer.png" alt="adminsettings" ondblclick="adminsettings()" />
 		</div>
+	<?php else:
+	header("location: login.php");
+	exit;
+	endif; ?>
 	</div>
 
 	<script type="text/javascript" src="api/config.php"></script>

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -254,7 +254,7 @@ $configsetup = [
 		],
 		'password' => [
 			'type' => 'input',
-			'placeholder' => 'booth',
+			'placeholder' => NULL,
 			'name' => 'login_password',
 			'value' => $config['login_password']
 		]

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -257,6 +257,16 @@ $configsetup = [
 			'placeholder' => NULL,
 			'name' => 'login_password',
 			'value' => $config['login_password']
+		],
+		'protect_admin' => [
+			'type' => 'checkbox',
+			'name' => 'protect_admin',
+			'value' => $config['protect_admin']
+		],
+		'protect_index' => [
+			'type' => 'checkbox',
+			'name' => 'protect_index',
+			'value' => $config['protect_index']
 		]
 	],
 	'folders' => [

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -240,6 +240,31 @@ $configsetup = [
 			'value' => $config['rounded_corners']
 		]
 	],
+	'login' => [
+		'login_enabled' => [
+			'type' => 'checkbox',
+			'name' => 'login_enabled',
+			'value' => $config['login_enabled']
+		],
+		'username' => [
+			'type' => 'input',
+			'placeholder' => 'Photo',
+			'name' => 'login_username',
+			'value' => $config['login_username']
+		],
+		'password' => [
+			'type' => 'input',
+			'placeholder' => 'booth',
+			'name' => 'login_password',
+			'value' => $config['login_password']
+		],
+		'random1' => [
+			'type' => 'input',
+			'placeholder' => 'Q4KbXus?G',
+			'name' => 'login_random1',
+			'value' => $config['login_random1']
+		]
+	],
 	'folders' => [
 		'images' => [
 			'type' => 'input',

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -257,12 +257,6 @@ $configsetup = [
 			'placeholder' => 'booth',
 			'name' => 'login_password',
 			'value' => $config['login_password']
-		],
-		'random1' => [
-			'type' => 'input',
-			'placeholder' => 'Q4KbXus?G',
-			'name' => 'login_random1',
-			'value' => $config['login_random1']
 		]
 	],
 	'folders' => [

--- a/login.php
+++ b/login.php
@@ -1,0 +1,96 @@
+<?php
+session_start();
+
+require_once('lib/config.php');
+
+// LOGIN
+$username = $config['login_username'];
+$hashed_password = $config['login_password'];
+$error = false;
+
+if (isset($_POST['submit'])) {
+    if (isset($_POST['username']) && $_POST['username'] == $username && isset($_POST['password']) && password_verify($_POST["password"], $hashed_password)) {
+        //IF USERNAME AND PASSWORD ARE CORRECT SET THE LOG-IN SESSION
+        $_SESSION['auth'] = true;
+    } else {
+        // DISPLAY FORM WITH ERROR
+        $error = true;
+    }
+}
+// END LOGIN
+
+
+?>
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
+	<meta name="msapplication-TileColor" content="<?=$config['colors']['primary']?>">
+	<meta name="theme-color" content="<?=$config['colors']['primary']?>">
+
+	<title>Photobooth Login</title>
+
+	<!-- Favicon + Android/iPhone Icons -->
+	<link rel="apple-touch-icon" sizes="180x180" href="resources/img/apple-touch-icon.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="resources/img/favicon-32x32.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="resources/img/favicon-16x16.png">
+	<link rel="manifest" href="resources/img/site.webmanifest">
+	<link rel="mask-icon" href="resources/img/safari-pinned-tab.svg" color="#5bbad5">
+
+	<!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
+	<meta name="apple-mobile-web-app-capable" content="yes" />
+	<meta name="apple-mobile-web-app-status-bar-style" content="black" />
+
+	<link rel="stylesheet" href="node_modules/normalize.css/normalize.css" />
+	<link rel="stylesheet" href="node_modules/font-awesome/css/font-awesome.css" />
+	<link rel="stylesheet" href="node_modules/photoswipe/dist/photoswipe.css" />
+	<link rel="stylesheet" href="node_modules/photoswipe/dist/default-skin/default-skin.css" />
+	<link rel="stylesheet" href="resources/css/login.css" />
+	<?php if ($config['rounded_corners']): ?>
+	<link rel="stylesheet" href="resources/css/rounded.css" />
+	<?php endif; ?>
+</head>
+
+<body class="deselect">
+	<div id="wrapper">
+		<div class="login-panel">
+			<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)):
+			header("location: ../admin/index.php");
+			exit;
+			else: ?>
+			<form method='post' class="login">
+				<label for="username"><span data-l10n="login_username"></span></label>
+				<input type="text" name="username" id="username" autocomplete="on" required>
+				<label for="password"><span data-l10n="login_password"></span></label>
+				</br>
+				<input type="password" name="password" id="password" autocomplete="on" required>
+				</br></br>
+				<input type="submit" name="submit" value="Login" class="btn btn--tiny btn--flex">
+				<?php if ($error !== false) {
+					echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
+				} ?>
+			</form>
+			<?php endif; ?>
+			</br>
+			<a class="btn btn--tiny btn--flex" href="login.php"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a>
+		</div>
+
+
+		<div id="adminsettings">
+			<div style="position:absolute; bottom:0; right:0;">
+				<img src="resources/img/spacer.png" alt="adminsettings" ondblclick="adminsettings()" />
+			</div>
+		</div>
+
+	</div>
+
+	<script type="text/javascript" src="api/config.php"></script>
+	<script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
+	<script type="text/javascript" src="resources/js/adminshortcut.js"></script>
+	<script type="text/javascript" src="resources/js/l10n.js"></script>
+	<script type="text/javascript" src="resources/js/theme.js"></script>
+	<script type="text/javascript" src="resources/lang/<?php echo $config['language']; ?>.js"></script>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -53,46 +53,42 @@ if (isset($_POST['submit'])) {
 	<?php endif; ?>
 </head>
 
-<body class="deselect">
-	<div id="wrapper">
-		<div class="login-panel">
-			<h2>Photobooth Login</h2>
-			<hr>
-			<?php if($config['login_enabled'] && !(isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
-			<form method='post' class="login">
-				<label for="username"><span data-l10n="login_username"></span></label>
-				<input type="text" name="username" id="username" autocomplete="on" required>
-				<label for="password"><span data-l10n="login_password"></span></label>
-				</br>
-				<input type="password" name="password" id="password" autocomplete="on" required>
-				<span toggle="#password" class="password-toggle fa fa-eye"></span>
-				<p><input type="submit" name="submit" value="Login" class="btn btn--tiny btn--flex"></p>
-				<?php if ($error !== false) {
-					echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
-				} ?>
-			</form>
-			<hr>
-			<?php endif; ?>
-			<?php if(!$config['protect_admin'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
-			<p><a href="admin/index.php" class="btn btn--login"><i class="fa fa-cog"></i> <span data-l10n="admin_panel"></span></a></p>
-			<?php endif; ?>
-			<p><a href="gallery.php" class="btn btn--login"><i class="fa fa-th"></i> <span data-l10n="gallery"></span></a></p>
-			<p><a href="login.php" class="btn btn--login"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a></p>
-			<?php if(!$config['protect_index'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
-			<p><a href="./" class="btn btn--login" ><i class="fa fa-times"></i> <span data-l10n="close"></span></a></p>
-			<?php endif; ?>
-			<?php if(isset($_SESSION['auth']) && $_SESSION['auth'] === true): ?>
-			<p><a href="logout.php" class="btn btn--login"><i class="fa fa-sign-out"></i> <span data-l10n="logout"></span></a></p>
-			<?php endif; ?>
+<body class="loginbody">
+	<div class="login-panel">
+		<h2>Photobooth Login</h2>
+		<hr>
+		<?php if($config['login_enabled'] && !(isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
+		<form method='post' class="login">
+			<label for="username"><span data-l10n="login_username"></span></label>
+			<input type="text" name="username" id="username" autocomplete="on" required>
+			<label for="password"><span data-l10n="login_password"></span></label>
+			</br>
+			<input type="password" name="password" id="password" autocomplete="on" required>
+			<span toggle="#password" class="password-toggle fa fa-eye"></span>
+			<p><input type="submit" name="submit" value="Login" class="btn btn--tiny btn--flex"></p>
+			<?php if ($error !== false) {
+				echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
+			} ?>
+		</form>
+		<hr>
+		<?php endif; ?>
+		<?php if(!$config['protect_admin'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
+		<p><a href="admin/index.php" class="btn btn--login"><i class="fa fa-cog"></i> <span data-l10n="admin_panel"></span></a></p>
+		<?php endif; ?>
+		<p><a href="gallery.php" class="btn btn--login"><i class="fa fa-th"></i> <span data-l10n="gallery"></span></a></p>
+		<p><a href="login.php" class="btn btn--login"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a></p>
+		<?php if(!$config['protect_index'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
+		<p><a href="./" class="btn btn--login" ><i class="fa fa-times"></i> <span data-l10n="close"></span></a></p>
+		<?php endif; ?>
+		<?php if(isset($_SESSION['auth']) && $_SESSION['auth'] === true): ?>
+		<p><a href="logout.php" class="btn btn--login"><i class="fa fa-sign-out"></i> <span data-l10n="logout"></span></a></p>
+		<?php endif; ?>
+	</div>
+
+	<div id="adminsettings">
+		<div style="position:absolute; bottom:0; right:0;">
+			<img src="resources/img/spacer.png" alt="adminsettings" ondblclick="adminsettings()" />
 		</div>
-
-
-		<div id="adminsettings">
-			<div style="position:absolute; bottom:0; right:0;">
-				<img src="resources/img/spacer.png" alt="adminsettings" ondblclick="adminsettings()" />
-			</div>
-		</div>
-
 	</div>
 
 	<script type="text/javascript" src="api/config.php"></script>

--- a/login.php
+++ b/login.php
@@ -58,10 +58,7 @@ if (isset($_POST['submit'])) {
 		<div class="login-panel">
 			<h2>Photobooth Login</h2>
 			<hr>
-			<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)):
-			header("location: ../admin/index.php");
-			exit;
-			else: ?>
+			<?php if($config['login_enabled'] && !(isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
 			<form method='post' class="login">
 				<label for="username"><span data-l10n="login_username"></span></label>
 				<input type="text" name="username" id="username" autocomplete="on" required>
@@ -75,9 +72,17 @@ if (isset($_POST['submit'])) {
 				} ?>
 			</form>
 			<?php endif; ?>
-			</br>
-			<a class="btn btn--tiny btn--flex" href="login.php"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a>
-			<a class="btn btn--tiny btn--flex" id="close-btn" href="./"><i class="fa fa-times"></i> <span data-l10n="close"></span></a>
+			<?php if(!$config['protect_admin'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
+			<p><a href="admin/index.php" class="btn btn--tiny btn--flex"><i class="fa fa-cog"></i> <span data-l10n="admin_panel"></span></a></p>
+			<?php endif; ?>
+			<p><a href="gallery.php" class="btn btn--tiny btn--flex"><i class="fa fa-th"></i> <span data-l10n="gallery"></span></a></p>
+			<p><a href="login.php" class="btn btn--tiny btn--flex"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a></p>
+			<?php if(!$config['protect_index'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
+			<p><a href="./" class="btn btn--tiny btn--flex" ><i class="fa fa-times"></i> <span data-l10n="close"></span></a></p>
+			<?php endif; ?>
+			<?php if(isset($_SESSION['auth']) && $_SESSION['auth'] === true): ?>
+			<p><a href="logout.php" class="btn btn--tiny btn--flex"><i class="fa fa-sign-out"></i> <span data-l10n="logout"></span></a></p>
+			<?php endif; ?>
 		</div>
 
 

--- a/login.php
+++ b/login.php
@@ -71,17 +71,18 @@ if (isset($_POST['submit'])) {
 					echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
 				} ?>
 			</form>
+			<hr>
 			<?php endif; ?>
 			<?php if(!$config['protect_admin'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
-			<p><a href="admin/index.php" class="btn btn--tiny btn--flex"><i class="fa fa-cog"></i> <span data-l10n="admin_panel"></span></a></p>
+			<p><a href="admin/index.php" class="btn btn--login"><i class="fa fa-cog"></i> <span data-l10n="admin_panel"></span></a></p>
 			<?php endif; ?>
-			<p><a href="gallery.php" class="btn btn--tiny btn--flex"><i class="fa fa-th"></i> <span data-l10n="gallery"></span></a></p>
-			<p><a href="login.php" class="btn btn--tiny btn--flex"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a></p>
+			<p><a href="gallery.php" class="btn btn--login"><i class="fa fa-th"></i> <span data-l10n="gallery"></span></a></p>
+			<p><a href="login.php" class="btn btn--login"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a></p>
 			<?php if(!$config['protect_index'] || !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
-			<p><a href="./" class="btn btn--tiny btn--flex" ><i class="fa fa-times"></i> <span data-l10n="close"></span></a></p>
+			<p><a href="./" class="btn btn--login" ><i class="fa fa-times"></i> <span data-l10n="close"></span></a></p>
 			<?php endif; ?>
 			<?php if(isset($_SESSION['auth']) && $_SESSION['auth'] === true): ?>
-			<p><a href="logout.php" class="btn btn--tiny btn--flex"><i class="fa fa-sign-out"></i> <span data-l10n="logout"></span></a></p>
+			<p><a href="logout.php" class="btn btn--login"><i class="fa fa-sign-out"></i> <span data-l10n="logout"></span></a></p>
 			<?php endif; ?>
 		</div>
 

--- a/login.php
+++ b/login.php
@@ -65,7 +65,7 @@ if (isset($_POST['submit'])) {
 				<label for="password"><span data-l10n="login_password"></span></label>
 				</br>
 				<input type="password" name="password" id="password" autocomplete="on" required>
-				</br></br>
+				<p><input type="checkbox" class="password-visible"> <i class="icon fa fa-eye-slash"> </i> <span data-l10n="show_password"></span></p>
 				<input type="submit" name="submit" value="Login" class="btn btn--tiny btn--flex">
 				<?php if ($error !== false) {
 					echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
@@ -99,6 +99,7 @@ if (isset($_POST['submit'])) {
 	<script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
 	<script type="text/javascript" src="resources/js/adminshortcut.js"></script>
 	<script type="text/javascript" src="resources/js/l10n.js"></script>
+	<script type="text/javascript" src="resources/js/login.js"></script>
 	<script type="text/javascript" src="resources/js/theme.js"></script>
 	<script type="text/javascript" src="resources/lang/<?php echo $config['language']; ?>.js"></script>
 </body>

--- a/login.php
+++ b/login.php
@@ -56,6 +56,8 @@ if (isset($_POST['submit'])) {
 <body class="deselect">
 	<div id="wrapper">
 		<div class="login-panel">
+			<h2>Photobooth Login</h2>
+			<hr>
 			<?php if( !$config['login_enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)):
 			header("location: ../admin/index.php");
 			exit;

--- a/login.php
+++ b/login.php
@@ -65,8 +65,8 @@ if (isset($_POST['submit'])) {
 				<label for="password"><span data-l10n="login_password"></span></label>
 				</br>
 				<input type="password" name="password" id="password" autocomplete="on" required>
-				<p><input type="checkbox" class="password-visible"> <i class="icon fa fa-eye-slash"> </i> <span data-l10n="show_password"></span></p>
-				<input type="submit" name="submit" value="Login" class="btn btn--tiny btn--flex">
+				<span toggle="#password" class="password-toggle fa fa-eye"></span>
+				<p><input type="submit" name="submit" value="Login" class="btn btn--tiny btn--flex"></p>
 				<?php if ($error !== false) {
 					echo '<p style="color: red;"><span data-l10n="login_invalid"></span></p>';
 				} ?>

--- a/login.php
+++ b/login.php
@@ -75,6 +75,7 @@ if (isset($_POST['submit'])) {
 			<?php endif; ?>
 			</br>
 			<a class="btn btn--tiny btn--flex" href="login.php"><i class="fa fa-refresh"></i> <span data-l10n="reload"></span></a>
+			<a class="btn btn--tiny btn--flex" id="close-btn" href="./"><i class="fa fa-times"></i> <span data-l10n="close"></span></a>
 		</div>
 
 

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+session_destroy();
+unset($_SESSION['auth']);
+
+header("location: index.php");
+exit;

--- a/resources/js/login.js
+++ b/resources/js/login.js
@@ -1,0 +1,19 @@
+/* exported login */
+
+function showPassword() {
+    const x = document.getElementById('password');
+
+    if (x.type === 'password') {
+        x.type = 'text';
+        $('.icon').removeClass('fa-eye-slash');
+        $('.icon').addClass('fa-eye');
+    } else {
+        x.type = 'password';
+        $('.icon').removeClass('fa-eye');
+        $('.icon').addClass('fa-eye-slash');
+    }
+}
+
+$('.password-visible').on('click', function () {
+    showPassword();
+});

--- a/resources/js/login.js
+++ b/resources/js/login.js
@@ -5,15 +5,12 @@ function showPassword() {
 
     if (x.type === 'password') {
         x.type = 'text';
-        $('.icon').removeClass('fa-eye-slash');
-        $('.icon').addClass('fa-eye');
     } else {
         x.type = 'password';
-        $('.icon').removeClass('fa-eye');
-        $('.icon').addClass('fa-eye-slash');
     }
 }
 
-$('.password-visible').on('click', function () {
+$('.password-toggle').on('click', function () {
     showPassword();
+    $('.password-toggle').toggleClass('fa-eye fa-eye-slash');
 });

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -149,6 +149,5 @@ const L10N = {
     'logout': 'Ausloggen',
     'admin_panel': 'Admin Panel',
     'protect_admin': 'Admin Panel schützen',
-    'protect_index': 'Startseite schützen',
-    'show_password': 'Passwort einblenden'
+    'protect_index': 'Startseite schützen'
 }

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -140,5 +140,11 @@ const L10N = {
     'jpeg_quality_jpeg_quality_thumb': 'JPEG Qualität für Thumbnails (-1 ... 100)',
     'abort': 'Abbrechen',
     'dark_loader': 'Dunkle Anzeige beim Countdown',
-    'rounded_corners': 'Abgerundete Ecken'
+    'rounded_corners': 'Abgerundete Ecken',
+    'login': 'Login',
+    'login_enabled': 'Login aktivieren',
+    'login_username': 'Benutzername',
+    'login_password': 'Passwort',
+    'login_random1': 'Zufallsbedingt',
+    'login_invalid': 'Benutzername oder Passwort ungültig!'
 }

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -145,5 +145,6 @@ const L10N = {
     'login_enabled': 'Login aktivieren',
     'login_username': 'Benutzername',
     'login_password': 'Passwort',
-    'login_invalid': 'Benutzername oder Passwort ungültig!'
+    'login_invalid': 'Benutzername oder Passwort ungültig!',
+    'logout': 'Ausloggen'
 }

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -149,5 +149,6 @@ const L10N = {
     'logout': 'Ausloggen',
     'admin_panel': 'Admin Panel',
     'protect_admin': 'Admin Panel schützen',
-    'protect_index': 'Startseite schützen'
+    'protect_index': 'Startseite schützen',
+    'show_password': 'Passwort einblenden'
 }

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -145,6 +145,5 @@ const L10N = {
     'login_enabled': 'Login aktivieren',
     'login_username': 'Benutzername',
     'login_password': 'Passwort',
-    'login_random1': 'Zufallsbedingt',
     'login_invalid': 'Benutzername oder Passwort ungültig!'
 }

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -146,5 +146,8 @@ const L10N = {
     'login_username': 'Benutzername',
     'login_password': 'Passwort',
     'login_invalid': 'Benutzername oder Passwort ungültig!',
-    'logout': 'Ausloggen'
+    'logout': 'Ausloggen',
+    'admin_panel': 'Admin Panel',
+    'protect_admin': 'Admin Panel schützen',
+    'protect_index': 'Startseite schützen'
 }

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -145,5 +145,6 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_invalid': 'Username or password is invalid!'
+    'login_invalid': 'Username or password is invalid!',
+    'logout': 'Logout'
 }

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -149,5 +149,6 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen'
+    'protect_index': 'Protect start screen',
+    'show_password': 'Show password'
 }

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -146,5 +146,8 @@ const L10N = {
     'login_username': 'Username',
     'login_password': 'Password',
     'login_invalid': 'Username or password is invalid!',
-    'logout': 'Logout'
+    'logout': 'Logout',
+    'admin_panel': 'Admin panel',
+    'protect_admin': 'Protect admin panel',
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -145,6 +145,5 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_random1': 'Random',
     'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -149,6 +149,5 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen',
-    'show_password': 'Show password'
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -140,5 +140,11 @@ const L10N = {
     'jpeg_quality_jpeg_quality_thumb': 'JPEG quality for thumbnails (-1 ... 100)',
     'abort': 'Abort',
     'dark_loader': 'Dark display while countdown',
-    'rounded_corners': 'Rounded corners'
+    'rounded_corners': 'Rounded corners',
+    'login': 'Login',
+    'login_enabled': 'Login enabled',
+    'login_username': 'Username',
+    'login_password': 'Password',
+    'login_random1': 'Random',
+    'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -145,5 +145,6 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_invalid': 'Username or password is invalid!'
+    'login_invalid': 'Username or password is invalid!',
+    'logout': 'Logout'
 }

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -149,5 +149,6 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen'
+    'protect_index': 'Protect start screen',
+    'show_password': 'Show password'
 }

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -146,5 +146,8 @@ const L10N = {
     'login_username': 'Username',
     'login_password': 'Password',
     'login_invalid': 'Username or password is invalid!',
-    'logout': 'Logout'
+    'logout': 'Logout',
+    'admin_panel': 'Admin panel',
+    'protect_admin': 'Protect admin panel',
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -140,5 +140,11 @@ const L10N = {
     'jpeg_quality_jpeg_quality_thumb': 'Calidad de JPEG para thumbnails (-1 ... 100)',
     'abort': 'Abortar',
     'dark_loader': 'Dark display while countdown',
-    'rounded_corners': 'Rounded corners'
+    'rounded_corners': 'Rounded corners',
+    'login': 'Login',
+    'login_enabled': 'Login enabled',
+    'login_username': 'Username',
+    'login_password': 'Password',
+    'login_random1': 'Random',
+    'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -145,6 +145,5 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_random1': 'Random',
     'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -149,6 +149,5 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen',
-    'show_password': 'Show password'
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -145,5 +145,6 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_invalid': 'Username or password is invalid!'
+    'login_invalid': 'Username or password is invalid!',
+    'logout': 'Logout'
 }

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -149,5 +149,6 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen'
+    'protect_index': 'Protect start screen',
+    'show_password': 'Show password'
 }

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -146,5 +146,8 @@ const L10N = {
     'login_username': 'Username',
     'login_password': 'Password',
     'login_invalid': 'Username or password is invalid!',
-    'logout': 'Logout'
+    'logout': 'Logout',
+    'admin_panel': 'Admin panel',
+    'protect_admin': 'Protect admin panel',
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -140,5 +140,11 @@ const L10N = {
     'jpeg_quality_jpeg_quality_thumb': 'JPEG qualité des thumbnails (-1 ... 100)',
     'abort': 'Avorter',
     'dark_loader': 'Dark display while countdown',
-    'rounded_corners': 'Rounded corners'
+    'rounded_corners': 'Rounded corners',
+    'login': 'Login',
+    'login_enabled': 'Login enabled',
+    'login_username': 'Username',
+    'login_password': 'Password',
+    'login_random1': 'Random',
+    'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -145,6 +145,5 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_random1': 'Random',
     'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -149,6 +149,5 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen',
-    'show_password': 'Show password'
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -144,6 +144,5 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_random1': 'Random',
     'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -148,6 +148,5 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen',
-    'show_password': 'Show password'
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -144,5 +144,6 @@ const L10N = {
     'login_enabled': 'Login enabled',
     'login_username': 'Username',
     'login_password': 'Password',
-    'login_invalid': 'Username or password is invalid!'
+    'login_invalid': 'Username or password is invalid!',
+    'logout': 'Logout'
 }

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -139,5 +139,11 @@ const L10N = {
     'jpeg_quality_jpeg_quality_thumb': 'Ποιότητα JPEG για μικρογραφίες (-1 ... 100)',
     'abort': 'Αποβάλλω',
     'dark_loader': 'Dark display while countdown',
-    'rounded_corners': 'Rounded corners'
+    'rounded_corners': 'Rounded corners',
+    'login': 'Login',
+    'login_enabled': 'Login enabled',
+    'login_username': 'Username',
+    'login_password': 'Password',
+    'login_random1': 'Random',
+    'login_invalid': 'Username or password is invalid!'
 }

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -145,5 +145,8 @@ const L10N = {
     'login_username': 'Username',
     'login_password': 'Password',
     'login_invalid': 'Username or password is invalid!',
-    'logout': 'Logout'
+    'logout': 'Logout',
+    'admin_panel': 'Admin panel',
+    'protect_admin': 'Protect admin panel',
+    'protect_index': 'Protect start screen'
 }

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -148,5 +148,6 @@ const L10N = {
     'logout': 'Logout',
     'admin_panel': 'Admin panel',
     'protect_admin': 'Protect admin panel',
-    'protect_index': 'Protect start screen'
+    'protect_index': 'Protect start screen',
+    'show_password': 'Show password'
 }

--- a/resources/sass/login.scss
+++ b/resources/sass/login.scss
@@ -32,3 +32,11 @@ input[type="password"] {
   position: relative;
   max-width: 100%;
 }
+
+.password-toggle {
+  float: right;
+  margin-left: -25px;
+  margin-top: 5px;
+  position: relative;
+  z-index: 2;
+}

--- a/resources/sass/login.scss
+++ b/resources/sass/login.scss
@@ -3,13 +3,13 @@
 @import "partials/basic";
 @import "partials/button";
 
-#wrapper {
+.loginbody {
   display: block;
   position: relative;
   overflow-y: auto;
   background-color: $mainColor;
   background-image: $adminBackground;
-  background-position: center center;
+  background-position: center center no-repeat;
   width: 100%;
   height: 100%;
 }

--- a/resources/sass/login.scss
+++ b/resources/sass/login.scss
@@ -1,0 +1,34 @@
+@import "modules/theme";
+@import "partials/fonts";
+@import "partials/basic";
+@import "partials/button";
+
+#wrapper {
+  display: block;
+  position: relative;
+  overflow-y: auto;
+  background-color: $mainColor;
+  background-image: $adminBackground;
+  background-position: center center;
+  width: 100%;
+  height: 100%;
+}
+
+input[type="text"],
+input[type="password"] {
+  background: #f8f9fc;
+  border: 1px solid #eff2f7;
+  border-radius: 4px;
+  width: 100%;
+  padding: 0 10px;
+}
+
+.login-panel {
+  width: 500px;
+  padding: 30px 30px 90px;
+  height: auto;
+  margin: 50px auto;
+  background: #fff;
+  position: relative;
+  max-width: 100%;
+}

--- a/resources/sass/partials/_button.scss
+++ b/resources/sass/partials/_button.scss
@@ -22,6 +22,11 @@
         width: auto;
     }
 
+    &--login {
+        padding: 12px 18px;
+        width: 50%;
+    }
+
     &:active,
     &:focus,
     &:hover {

--- a/resources/sass/rounded.scss
+++ b/resources/sass/rounded.scss
@@ -63,6 +63,11 @@
   }
 }
 
+.login-panel {
+  border: 0 none;
+  border-radius: 10px;
+}
+
 button {
   border: 2px solid #eee;
   border-radius: 10px;

--- a/scripts/pack-build.js
+++ b/scripts/pack-build.js
@@ -57,6 +57,8 @@ function createArchive(fileName, archive) {
     archive.directory('resources');
     archive.directory('template');
     archive.directory('vendor');
+    archive.file('login.php');
+    archive.file('logout.php');
     archive.file('chromakeying.php');
     archive.file('index.php');
     archive.file('phpinfo.php');


### PR DESCRIPTION
Thanks to @F4bsi for the initial implementation! Fix: https://github.com/andreknieriem/photobooth/issues/39

Who likes to give it a try can use my fork at https://github.com/andi34/photobooth which also contains different other open pull-requests and some other extras.

Initial change reworked by Andreas Blaesius 11 Oct. 2019:
- adjust for Photobooth v2.0.0
- add translations
- make error message translatable
- make login panel translatable

Changes December 2019:
- own login page
- optional: allow to protect admin panel (enabled by default) and start page (disabled by default) with login
- always allow to access the gallery (`gallery.php`) from login page
- don't store clear text password

Changes January 2020:
- Show / hide cleartext password at login via toggle

# Main settings
![Screenshot_20191230-174340](https://user-images.githubusercontent.com/6080900/71591325-353d8100-2b2c-11ea-81cb-99ad342d6603.jpg)

# Once saved the password is turned into a hash
![Screenshot_20191230-174444](https://user-images.githubusercontent.com/6080900/71591346-45edf700-2b2c-11ea-8c7e-2d4d9b236628.jpg)

# Login page, admin panel protected
![Screenshot_20191230-174349](https://user-images.githubusercontent.com/6080900/71591362-500ff580-2b2c-11ea-9299-b2e06946bc1c.jpg)

# logged in
![Screenshot_20191230-174424](https://user-images.githubusercontent.com/6080900/71591392-6ddd5a80-2b2c-11ea-8d31-85f5d61b346c.jpg)

# admin panel and start page protected
![Screenshot_20191230-174455](https://user-images.githubusercontent.com/6080900/71591415-8188c100-2b2c-11ea-8cbc-b4b6dd589b91.jpg)

Using rounded corners design, but also without runded corners I need to fix the button optics.

Who's connected can always access the gallery via `gallery.php`.

