### PR TITLE
Workaround wedding symbol not getting saved

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -55,7 +55,7 @@ $config['folders']['data'] = 'data';
 $config['is_wedding'] = false;
 $config['wedding']['groom'] = 'Name 1';
 $config['wedding']['bride'] = 'Name 2';
-$config['wedding']['symbol'] = 'fa-heart-o';
+$config['wedding']['symbol'] = null;
 
 // GALLERY
 // should the gallery list the newest pictures first?


### PR DESCRIPTION

We only save changed config options, this seems to cause trouble here.
To temporally fix https://github.com/andreknieriem/photobooth/issues/130 don't define a symbol by default.