### PR TITLE
Small security changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A Photobooth webinterface for Raspberry Pi and Windows.
 
 ## :gear: Prerequisites
 - gphoto2 installed, if used on a Raspberry for DSLR control
-- digiCamControl, if used unter Windows for DSLR control
+- digiCamControl, if used under Windows for DSLR control
 - Apache
 
 ## :wrench: Installation & Troubleshooting

--- a/install-raspbian.sh
+++ b/install-raspbian.sh
@@ -69,7 +69,22 @@ apt dist-upgrade -y
 info "### Photobooth needs some software to run."
 apt install -y libapache2-mod-php php-gd gphoto2 unclutter
 
-cd /var/www/
+echo -e "\033[0;33m### Is Photobooth the only website on this system?"
+read -p "### Warning: If typing y, the whole /var/www/html folder will be removed! [y/N] " -n 1 -r deleteHtmlFolder
+echo -e "\033[0m"
+
+if [ "$deleteHtmlFolder" != "${deleteHtmlFolder#[Yy]}" ] ;then
+    info "### Ok, we will replace the html folder with the Photobooth."
+    cd /var/www/
+    rm -rf html
+    INSTALLFOLDER="html"
+    INSTALLFOLDERPATH="/var/www/html/"
+else
+    info "### Ok, we will install Photobooth into /var/www/html/photobooth."
+    cd /var/www/html/
+    INSTALLFOLDER="photobooth"
+    INSTALLFOLDERPATH="/var/www/html/$INSTALLFOLDER/"
+fi
 
 echo -e "\033[0;33m### Do you like to install from git? This will take more"
 read -p "### time and is recommended only for brave users. [y/N] " -n 1 -r
@@ -88,8 +103,8 @@ then
     apt install -y yarn
 
     info "### Now we are going to install Photobooth."
-    git clone https://github.com/andreknieriem/photobooth html
-    cd /var/www/html
+    git clone https://github.com/andreknieriem/photobooth $INSTALLFOLDER
+    cd $INSTALLFOLDERPATH
     LATEST_VERSION=$( git describe --tags `git rev-list --tags --max-count=1` )
     info "### We ar installing version $LATEST_VERSION".
     git checkout $LATEST_VERSION
@@ -109,10 +124,13 @@ else
         jq '.assets[].browser_download_url | select(endswith(".tar.gz"))' |
         xargs curl -L --output /tmp/photobooth-latest.tar.gz
 
-    tar -xzvf /tmp/photobooth-latest.tar.gz -C /var/www/html/
+    mkdir $INSTALLFOLDERPATH
+    tar -xzvf /tmp/photobooth-latest.tar.gz -C $INSTALLFOLDERPATH
+    cd $INSTALLFOLDERPATH
 fi
 
 info "### Setting permissions."
+chown -R pi:pi $INSTALLFOLDERPATH
 mkdir data
 chown -R www-data:www-data data
 chown -R www-data:www-data config

--- a/install-raspbian.sh
+++ b/install-raspbian.sh
@@ -124,7 +124,7 @@ else
         jq '.assets[].browser_download_url | select(endswith(".tar.gz"))' |
         xargs curl -L --output /tmp/photobooth-latest.tar.gz
 
-    mkdir $INSTALLFOLDERPATH
+    mkdir -p $INSTALLFOLDERPATH
     tar -xzvf /tmp/photobooth-latest.tar.gz -C $INSTALLFOLDERPATH
     cd $INSTALLFOLDERPATH
 fi

--- a/install-raspbian.sh
+++ b/install-raspbian.sh
@@ -70,8 +70,6 @@ info "### Photobooth needs some software to run."
 apt install -y libapache2-mod-php php-gd gphoto2 unclutter
 
 cd /var/www/
-rm -rf html
-mkdir html
 
 echo -e "\033[0;33m### Do you like to install from git? This will take more"
 read -p "### time and is recommended only for brave users. [y/N] " -n 1 -r
@@ -115,7 +113,9 @@ else
 fi
 
 info "### Setting permissions."
-chown -R www-data:www-data /var/www/
+mkdir data
+chown -R www-data:www-data data
+chown -R www-data:www-data config
 
 gpasswd -a www-data plugdev
 gpasswd -a www-data lp

--- a/lib/config.php
+++ b/lib/config.php
@@ -78,10 +78,13 @@ if (file_exists($my_config_file)) {
     $config = array_deep_merge($defaultConfig, $config);
 }
 
+// display errors only in dev mode
 if ($config['dev']) {
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);
     error_reporting(E_ALL);
+}else {
+    error_reporting(0);
 }
 
 if (is_array($config['color_theme'])) {
@@ -92,12 +95,14 @@ if (is_array($config['color_theme'])) {
     $config['colors'] = $colors['default'];
 }
 
-if (file_exists($my_config_file) && !is_writable($my_config_file)) {
+// check config file and permissions
+if (!file_exists($my_config_file)) {
+    die('Abort. Can not find config/my.config.inc.php. Create it manually based on the config.inc.php template.');
+} elseif(!is_writable($my_config_file)) {
     die('Abort. Can not write config/my.config.inc.php.');
-} elseif (!file_exists($my_config_file) && !is_writable(__DIR__ . '/../config/')) {
-    die('Abort. Can not create config/my.config.inc.php. Config folder is not writable.');
 }
 
+// create folder
 foreach ($config['folders'] as $key => $folder) {
     $path = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . $folder;
 


### PR DESCRIPTION
I corrected some security issues, mostly in the install sh script:

1. The install script removes the `/var/www/html` recursively without asking the user (!) This is really dangerous! Think of a person who only wants to install this photobooth software on an existing system with a lot of websites. He or she will loose the entire webserver content by using the sh script.

2. Changing the owner of the entire `/var/www/html` folder is also a pretty bad idea. Always think of the [PoLP](https://en.wikipedia.org/wiki/Principle_of_least_privilege)! A better approach is only giving the webserver write access to the `data` and (perhaps) `config` folder.

3. In addition, the app forces the user to give write access to the whole `config` folder, but it only needs write permissions on the personal config file and that only if the user wants to use the admin backend.

4. Disable error display in production mode.

A few thought-provoking impulses:

- Perhaps update the wiki and inform other persons that the `data` folder and the personal config file must be writable by the webserver
- Think of forcing the user to give write access to some config parts. If they don't want to use the admin backend, permissions on the config file aren't needed.