### PR TITLE
Add option to show/hide error messages

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -5,7 +5,7 @@
 
 $config = array();
 $config['dev'] = false;
-$config['show_error_messages'] = false;
+$config['show_error_messages'] = true;
 $config['use_print'] = false;
 $config['use_qr'] = true;
 $config['print_qrcode'] = true;

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -5,6 +5,7 @@
 
 $config = array();
 $config['dev'] = false;
+$config['show_error_messages'] = false;
 $config['use_print'] = false;
 $config['use_qr'] = true;
 $config['print_qrcode'] = true;

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -33,6 +33,11 @@ $configsetup = [
 			'name' => 'dev',
 			'value' => $config['dev']
 		],
+		'show_error_messages' => [
+			'type' => 'checkbox',
+			'name' => 'show_error_messages',
+			'value' => $config['show_error_messages']
+		],
 		'file_format_date' => [
 			'type' => 'checkbox',
 			'name' => 'file_format_date',

--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -223,7 +223,7 @@ const photoBooth = (function () {
             $('.spinner').hide();
             $('.loading').empty()
             $('.loading').append($('<p>').text(L10N.error));
-            if (config.show_error_messages) {
+            if (config.show_error_messages || config.dev) {
                 $('.loading').append($('<p class="text-muted">').text(data.error));
             }
             $('.loading').append($('<a class="btn" href="./">').text(L10N.reload));

--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -223,7 +223,9 @@ const photoBooth = (function () {
             $('.spinner').hide();
             $('.loading').empty()
             $('.loading').append($('<p>').text(L10N.error));
-            $('.loading').append($('<p class="text-muted">').text(data.error));
+            if (config.show_error_messages) {
+                $('.loading').append($('<p class="text-muted">').text(data.error));
+            }
             $('.loading').append($('<a class="btn" href="./">').text(L10N.reload));
         }, 500);
     }

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -1,5 +1,6 @@
 /* exported L10N */
 const L10N = {
+    'show_error_messages': 'Fehlermeldungen anzeigen',
     'general_default_imagefilter': 'Standardbildfilter',
     'default_imagefilter': 'Bildfilter auswählen',
     'general_collage_cntdwn_time': 'Collage-Countdown Timer in Sekunden',

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -1,5 +1,6 @@
 /* exported L10N */
 const L10N = {
+    'show_error_messages': 'Show error messages',
     'general_default_imagefilter': 'Default image filter',
     'default_imagefilter': 'Choose image filter',
     'general_collage_cntdwn_time': 'Collage-countdown timer in seconds',

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -1,5 +1,6 @@
 /* exported L10N */
 const L10N = {
+    'show_error_messages': 'Mostrar mensajes de error',
     'general_default_imagefilter': 'Filtro de imagen predeterminado',
     'default_imagefilter': 'Elegir filtro de imagen',
     'general_collage_cntdwn_time': 'Cuenta regresiva del collage en segundos',

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -1,5 +1,6 @@
 /* exported L10N */
 const L10N = {
+    'show_error_messages': 'Afficher les messages d\'erreur',
     'general_default_imagefilter': 'Filtre d\'image par défaut',
     'default_imagefilter': 'Choisissez le filtre d\'image',
     'general_collage_cntdwn_time': 'Montage photo compte à rebours en secondes',

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -1,5 +1,6 @@
 /* exported L10N */
 const L10N = {
+    'show_error_messages': 'Εμφάνιση μηνυμάτων σφάλματος',
     'general_default_imagefilter': 'Προεπιλεγμένο φίλτρο εικόνας',
     'default_imagefilter': 'Επιλέξτε φίλτρο εικόνας',
     'general_collage_cntdwn_time': 'Χρονοδιακόπτης αντίστροφης μέτρησης φωτογραφιών σε δευτερόλεπτα',


### PR DESCRIPTION
Fix https://github.com/andreknieriem/photobooth/issues/160

### Option in admin panel
![Screenshot_2019-10-25_07-39-11](https://user-images.githubusercontent.com/6080900/67545797-c5111a00-f6fa-11e9-80b5-7cfa69d32e00.png)

### disabled error messages
![Screenshot_2019-10-25_07-39-27](https://user-images.githubusercontent.com/6080900/67545787-bd517580-f6fa-11e9-9e43-67f9e29a1eb1.png)

### enabled error messages
![Screenshot_2019-10-25_07-39-49](https://user-images.githubusercontent.com/6080900/67545792-c2162980-f6fa-11e9-9cbf-ab8628a042de.png)
