### PR TITLE
Fix errors in arrayDeepMerge for non-existing keys

### DIFF
--- a/lib/arrayDeepMerge.php
+++ b/lib/arrayDeepMerge.php
@@ -32,7 +32,7 @@ function array_deep_merge()
         $args[2] = array();
         if (is_array($args[0]) and is_array($args[1])) {
             foreach (array_unique(array_merge(array_keys($args[0]), array_keys($args[1]))) as $key) {
-                if (is_string($key) and is_array($args[0][$key]) and is_array($args[1][$key])) {
+                if (is_string($key) and array_key_exists($key, $args[0]) and is_array($args[0][$key]) and array_key_exists($key, $args[1]) and is_array($args[1][$key])) {
                     $args[2][$key] = array_deep_merge($args[0][$key], $args[1][$key]);
                 } elseif (is_string($key) and isset($args[0][$key]) and isset($args[1][$key])) {
                     $args[2][$key] = $args[1][$key];


### PR DESCRIPTION
This is to get rid of the following errors during config parsing:

```console
[Fri Nov 01 14:53:38.342167 2019] [php7:notice] [pid 1467] [client 192.168.1.11:57959] PHP Notice:  Undefined index: folders in /var/www/html/lib/arrayDeepMerge.php on line 35, referer: http://192.168.1.31/
[Fri Nov 01 14:53:38.342308 2019] [php7:notice] [pid 1467] [client 192.168.1.11:57959] PHP Notice:  Undefined index: event in /var/www/html/lib/arrayDeepMerge.php on line 35, referer: http://192.168.1.31/
[Fri Nov 01 14:53:38.342369 2019] [php7:notice] [pid 1467] [client 192.168.1.11:57959] PHP Notice:  Undefined index: gallery in /var/www/html/lib/arrayDeepMerge.php on line 35, referer: http://192.168.1.31/
[Fri Nov 01 14:53:38.342420 2019] [php7:notice] [pid 1467] [client 192.168.1.11:57959] PHP Notice:  Undefined index: textonprint in /var/www/html/lib/arrayDeepMerge.php on line 35, referer: http://192.168.1.31/
[Fri Nov 01 14:53:38.342489 2019] [php7:notice] [pid 1467] [client 192.168.1.11:57959] PHP Notice:  Undefined index: take_picture in /var/www/html/lib/arrayDeepMerge.php on line 35, referer: http://192.168.1.31/
[Fri Nov 01 14:53:38.342536 2019] [php7:notice] [pid 1467] [client 192.168.1.11:57959] PHP Notice:  Undefined index: print in /var/www/html/lib/arrayDeepMerge.php on line 35, referer: http://192.168.1.31/
[Fri Nov 01 14:53:38.342582 2019] [php7:notice] [pid 1467] [client 192.168.1.11:57959] PHP Notice:  Undefined index: colors in /var/www/html/lib/arrayDeepMerge.php on line 35, referer: http://192.168.1.31/
```
