### PR TITLE
[WIP] Easy fallback in case of missing translations

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -35,19 +35,19 @@ require_once('../lib/configsetup.inc.php');
 			</span>
 			<span class="saving">
 				<i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-				<span data-l10n="saving"></span>
+				<span data-l10n="saving">Saving...</span>
 			</span>
 			<span class="success">
 				<i class="fa fa-check"></i>
-				<span data-l10n="success"></span>
+				<span data-l10n="success">Success!</span>
 			</span>
 			<span class="error">
 				<i class="fa fa-times"></i>
-				<span data-l10n="saveerror"></span>
+				<span data-l10n="saveerror">Ooops! Something went wrong!</span>
 			</span>
 		</button>
 		<div id="checkVersion">
-			<p><a href="#" class="btn btn--tiny btn--flex"><span data-l10n="check_version"></span></a></p>
+			<p><a href="#" class="btn btn--tiny btn--flex"><span data-l10n="check_version">Check version</span></a></p>
 		</div>
 		<div class="accordion">
 			<form>
@@ -63,22 +63,22 @@ require_once('../lib/configsetup.inc.php');
 						';
 
 						foreach($fields as $key => $field){
+							$nameField = 'name="' . $key . '"';
 							echo '<div class="form-row">';
 							switch($field['type']) {
 								case 'input':
-									echo '<label data-l10n="'.$panel.'_'.$key.'">'.$panel.'_'.$key.'</label><input type="text" name="'.$field['name'].'" value="'.$field[
-										'value'].'" placeholder="'.$field['placeholder'].'"/>';
+									echo '<label data-l10n="'.$panel.'_'.$key.'">' . $field['name'] . '</label><input type="text" ' . $nameField . ' value="'.$field['value'].'" placeholder="'.$field['placeholder'].'"/>';
 								break;
 								case 'checkbox':
 									$checked = '';
 									if ($field['value'] == 'true') {
 										$checked = ' checked="checked"';
 									}
-									echo '<label><input type="checkbox" '.$checked.' name="'.$field['name'].'" value="true"/><span data-l10n="'.$key.'">'.$key.'</span></label>';
+									echo '<label><input type="checkbox" '.$checked.' ' . $nameField . ' value="true"/><span data-l10n="'.$key.'" class="fooo">' . $field['name'] . '</span></label>';
 								break;
 								case 'select':
-									echo '<label data-l10n="'.$panel.'_'.$key.'">'.$panel.'_'.$key.'</label><select name="'.$field['name'].'">
-										<option data-l10n="'.$key.'"></option>
+									echo '<label data-l10n="'.$panel.'_'.$key.'">' . $field['name'] . '</label><select ' . $nameField . '>
+										<option data-l10n="'.$key.'">' . $field['name'] . '</option>
 									';
 										foreach($field['options'] as $val => $option) {
 											$selected = '';
@@ -99,19 +99,19 @@ require_once('../lib/configsetup.inc.php');
 			</form>
 			<button class="save-btn">
 				<span class="save">
-					<span data-l10n="save"></span>
+					<span data-l10n="save">Save</span>
 				</span>
 				<span class="saving">
 					<i class="fa fa-circle-o-notch fa-spin fa-fw"></i>
-					<span data-l10n="saving"></span>
+					<span data-l10n="saving">Saving...</span>
 				</span>
 				<span class="success">
 					<i class="fa fa-check"></i>
-					<span data-l10n="success"></span>
+					<span data-l10n="success">Success!</span>
 				</span>
 				<span class="error">
 					<i class="fa fa-times"></i>
-					<span data-l10n="saveerror"></span>
+					<span data-l10n="saveerror">Ooops! Something went wrong!</span>
 				</span>
 			</button>
 		</div>

--- a/chromakeying.php
+++ b/chromakeying.php
@@ -72,13 +72,13 @@ if (file_exists($keyingimage)) {
 		</div>
 
 		<div class="chroma-control-bar">
-			<a class="btn btn--flex" id="save-btn" href="#"><i class="fa fa-floppy-o"></i> <span data-l10n="save"></span></a>
+			<a class="btn btn--flex" id="save-btn" href="#"><i class="fa fa-floppy-o"></i> <span data-l10n="save">Save</span></a>
 
 			<?php if ($config['use_print']): ?>
-				<a class="btn btn--flex" id="print-btn" href="#"><i class="fa fa-print"></i> <span data-l10n="print"></span></a>
+				<a class="btn btn--flex" id="print-btn" href="#"><i class="fa fa-print"></i> <span data-l10n="print">Print</span></a>
 			<?php endif; ?>
 
-			<a class="btn btn--flex" id="close-btn" href="#"><i class="fa fa-times"></i> <span data-l10n="close"></span></a>
+			<a class="btn btn--flex" id="close-btn" href="#"><i class="fa fa-times"></i> <span data-l10n="close">Close</span></a>
 		</div>
 	<?php else:?>
 		<div style="text-align:center;padding-top:250px">

--- a/gallery.php
+++ b/gallery.php
@@ -44,7 +44,7 @@ $imagelist = ($config['newest_first'] === true) ? array_reverse($images) : $imag
 
 	<div class="send-mail">
 		<i class="fa fa-times" id="send-mail-close"></i>
-		<p data-l10n="insertMail"></p>
+		<p data-l10n="insertMail">Enter your email address to receive the photo</p>
 		<form id="send-mail-form" style="margin: 0;">
 			<input class="mail-form-input" size="35" type="email" name="sendTo">
 			<input id="mail-form-image" type="hidden" name="image" value="">

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -5,7 +5,7 @@ $configsetup = [
 	'general' => [
 		'language' => [
 			'type' => 'select',
-			'name' => 'language',
+			'name' => 'Language',
 			'placeholder' => 'language',
 			'options' => [
 				'de' => 'DE',
@@ -19,48 +19,48 @@ $configsetup = [
 		'start_screen_title' => [
 			'type' => 'input',
 			'placeholder' => 'Photobooth',
-			'name' => 'start_screen_title',
+			'name' => 'Start screen title',
 			'value' => $config['start_screen_title']
 		],
 		'start_screen_subtitle' => [
 			'type' => 'input',
 			'placeholder' => 'Webinterface by André Rinas',
-			'name' => 'start_screen_subtitle',
+			'name' => 'Start screen subtitle',
 			'value' => $config['start_screen_subtitle']
 		],
 		'dev' => [
 			'type' => 'checkbox',
-			'name' => 'dev',
+			'name' => 'Dev mode',
 			'value' => $config['dev']
 		],
 		'show_error_messages' => [
 			'type' => 'checkbox',
-			'name' => 'show_error_messages',
+			'name' => 'Show error messages',
 			'value' => $config['show_error_messages']
 		],
 		'file_format_date' => [
 			'type' => 'checkbox',
-			'name' => 'file_format_date',
+			'name' => 'Use dateformat images',
 			'value' => $config['file_format_date']
 		],
 		'use_print' => [
 			'type' => 'checkbox',
-			'name' => 'use_print',
+			'name' => 'Use Print',
 			'value' => $config['use_print']
 		],
 		'use_qr' => [
 			'type' => 'checkbox',
-			'name' => 'use_qr',
+			'name' => 'Use QR Codes',
 			'value' => $config['use_qr']
 		],
 		'use_mail' => [
 			'type' => 'checkbox',
-			'name' => 'use_mail',
+			'name' => 'Use e-mail',
 			'value' => $config['use_mail']
 		],
 		'photo_key' => [
 			'type' => 'input',
-			'name' => 'photo_key',
+			'name' => 'Key code which triggers a photo',
 			'placeholder' => '',
 			'value' => $config['photo_key']
 		],

--- a/resources/js/l10n.js
+++ b/resources/js/l10n.js
@@ -9,6 +9,7 @@ function l10n(elem) {
 
         if (!translation) {
             console.warn('No translation for: ', key);
+            return;
         }
 
         item.html(translation || key);


### PR DESCRIPTION
This is a "POC" for a very simple improvement  to display fallback text in case of missing translations.

The change is basically to use the `name` field for the default text. IMO there is no need for the name being used as "key" - why not use the already existing keys?

Note: I did not complete this PR as I do not know if this will be accepted or not.