### PR TITLE
Switch to NGINX by default, make Apache and Lighttpd optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A Photobooth webinterface for Raspberry Pi and Windows.
 ## :gear: Prerequisites
 - gphoto2 installed, if used on a Raspberry for DSLR control
 - digiCamControl, if used unter Windows for DSLR control
-- Apache
+- NGINX or Apache
 
 ## :wrench: Installation & Troubleshooting
 Please follow the installation instructions in our [Photobooth-Wiki](https://github.com/andreknieriem/photobooth/wiki) to setup Photobooth.
@@ -76,3 +76,4 @@ Please take a look at the changelog in our [Photobooth Wiki](https://github.com/
 - [vdubuk](https://github.com/vdubuk)
 - [msmedien](https://github.com/msmedien)
 - [sualko](https://github.com/sualko)
+- [rawbertp](https://github.com/rawbertp)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A Photobooth webinterface for Raspberry Pi and Windows.
 ## :gear: Prerequisites
 - gphoto2 installed, if used on a Raspberry for DSLR control
 - digiCamControl, if used unter Windows for DSLR control
-- NGINX or Apache
+- NGINX, Lighttpd or Apache
 
 ## :wrench: Installation & Troubleshooting
 Please follow the installation instructions in our [Photobooth-Wiki](https://github.com/andreknieriem/photobooth/wiki) to setup Photobooth.

--- a/install-raspbian.sh
+++ b/install-raspbian.sh
@@ -67,7 +67,7 @@ apt update
 apt dist-upgrade -y
 
 info "### Photobooth needs some software to run."
-apt install -y libapache2-mod-php php-gd gphoto2 unclutter
+apt install -y nginx php-fpm php-gd gphoto2 unclutter
 
 cd /var/www/
 rm -rf html
@@ -112,6 +112,26 @@ else
         xargs curl -L --output /tmp/photobooth-latest.tar.gz
 
     tar -xzvf /tmp/photobooth-latest.tar.gz -C /var/www/html/
+fi
+
+nginx_conf="/etc/nginx/sites-enabled/default"
+
+if [ -f "${nginx_conf}" ]; then
+    info "### Enable PHP in NGINX"
+    cp "${nginx_conf}" ~/nginx-default.bak
+    sed -i 's/^\(\s*\)index index\.html\(.*\)/\1index index\.php index\.html\2/g' "${nginx_conf}"
+    sed -i '/location ~ \\.php$ {/s/^\(\s*\)#/\1/g' "${nginx_conf}"
+    sed -i '/include snippets\/fastcgi-php.conf/s/^\(\s*\)#/\1/g' "${nginx_conf}"
+    sed -i '/fastcgi_pass unix:\/run\/php\//s/^\(\s*\)#/\1/g' "${nginx_conf}"
+    sed -i '/.*fastcgi_pass unix:\/run\/php\//,// { /}/s/^\(\s*\)#/\1/g; }' "${nginx_conf}"
+
+    info "### Testing NGINX config"
+    /usr/sbin/nginx -t -c /etc/nginx/nginx.conf
+
+    info "### Restarting NGINX"
+    systemctl reload nginx
+else
+    error "Can not find ${nginx_conf} !"
 fi
 
 info "### Setting permissions."

--- a/install-raspbian.sh
+++ b/install-raspbian.sh
@@ -58,6 +58,10 @@ nginx_webserver() {
         systemctl reload nginx
     else
         error "Can not find ${nginx_conf} !"
+        info "Using Apache Webserver !"
+        apt remove -y nginx php-fpm
+        apache_webserver
+
     fi
 }
 
@@ -90,6 +94,9 @@ EOF
         service lighttpd force-reload
     else
         error "Can not find ${php_conf} !"
+        info "Using Apache Webserver !"
+        apt remove -y lighttpd php-fpm
+        apache_webserver
     fi
 }
 


### PR DESCRIPTION
Thanks to @rawbertp .

By default NGINX is used.
To use Apache run `sudo bash install-raspbian.sh apache` ,
To use Lighttpd run `sudo bash install-raspbian.sh lighttpd`.

If PHP can not be enabled in config for NGINX or Lighttpd we'll use Apache as fallback as we don't need to enable PHP via config file.
Fix https://github.com/andreknieriem/photobooth/issues/177