### PR TITLE
[WIP] Allow restriction of resources by IP

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -2,6 +2,11 @@
 
 require_once('../lib/config.php');
 require_once('../lib/configsetup.inc.php');
+
+if ($config['use_privileged_access'] === true && !in_array($_SERVER['REMOTE_ADDR'], $config['privileged_ips']) ) {
+	die(sprintf("%s is not allowed to access this page", $_SERVER['REMOTE_ADDR']));
+}
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -66,8 +71,16 @@ require_once('../lib/configsetup.inc.php');
 							echo '<div class="form-row">';
 							switch($field['type']) {
 								case 'input':
-									echo '<label data-l10n="'.$panel.'_'.$key.'">'.$panel.'_'.$key.'</label><input type="text" name="'.$field['name'].'" value="'.$field[
-										'value'].'" placeholder="'.$field['placeholder'].'"/>';
+									echo '<label data-l10n="'.$panel.'_'.$key.'">'.$panel.'_'.$key.'</label>';
+									
+									if (is_array($field['value']) && !empty($field['value'])) {
+										foreach($field['value'] as $input_key => $input_value) {
+											echo '<input type="text" name="' . $field['name'] . '" value="'  .$input_value . '" placeholder="' . $field['placeholder'] . '"/>';
+										}
+									}
+									else {
+										echo '<input type="text" name="'.$field['name'].'" value="'.$field['value'].'" placeholder="'.$field['placeholder'].'"/>';
+									}
 								break;
 								case 'checkbox':
 									$checked = '';

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -102,3 +102,8 @@ $config['jpeg_quality_thumb'] = 60;
 $config['jpeg_quality_chroma'] = 70;
 $config['jpeg_quality_image'] = 80;
 
+// TODO (Documentation) For this feature to work the webserver must be configured
+// to listen on IPv4 interfaces only. It does not work with IPv6!
+$config['use_privileged_access'] = false; //TODO default to false
+$config['privileged_ips']['0'] = '127.0.0.1';
+//TODO there could be an option for 'guest_ips' - which, if empty, allows guest access for any IP

--- a/index.php
+++ b/index.php
@@ -4,6 +4,11 @@ require_once('lib/config.php');
 require_once('lib/db.php');
 require_once('lib/filter.php');
 
+if ($config['use_privileged_access'] === true && !in_array($_SERVER['REMOTE_ADDR'], $config['privileged_ips']) ) {
+	header('Location: gallery.php');
+	die(sprintf("%s is not allowed to access this page", $_SERVER['REMOTE_ADDR']));
+}
+
 $images = getImagesFromDB();
 $imagelist = ($config['newest_first'] === true) ? array_reverse($images) : $images;
 ?>

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -457,5 +457,18 @@ $configsetup = [
 			'name' => 'print[msg]',
 			'value' => $config['print']['msg']
 		]
+	],
+	'security' => [
+		'use_privileged_access' => [
+			'type' => 'checkbox',
+			'name' => 'use_privileged_access',
+			'value' => $config['use_privileged_access']
+		],
+		'privileged_ips' => [
+			'type' => 'input',
+			'placeholder' => '',
+			'name' => 'privileged_ips[]',
+			'value' => $config['privileged_ips']
+		]
 	]
 ];


### PR DESCRIPTION
Restrict certain configurable IP addresses to the gallery only. This feature can be turned on/off.

TODO (hints appreciated):

* Make the `security_privileged_ips` array editable in the admin area (the input fields are already shown but I need some JS to dynamically add/remove fields - if anyone has a good re-usable example, please let me know)
* Also support IP ranges/wildcards?
* Better naming
* Optional: There could be another (optional) list `guest_ips` to also restrict access to the gallery. If not set, everyone has access.

