### PR TITLE
Fix buttons in gallery on Apple devices using iOS < 13.x

### DIFF
--- a/resources/js/photoinit.js
+++ b/resources/js/photoinit.js
@@ -135,8 +135,9 @@ function initPhotoSwipeFromDOM (gallerySelector) {
     };
 
     // QR in gallery
-    $('.pswp__button--qrcode').on('click', function (e) {
+    $('.pswp__button--qrcode').on('click touchstart', function (e) {
         e.preventDefault();
+        e.stopPropagation();
 
         const pswpQR = $('.pswp__qr');
 
@@ -154,8 +155,9 @@ function initPhotoSwipeFromDOM (gallerySelector) {
     });
 
     // print in gallery
-    $('.pswp__button--print').on('click', function (e) {
+    $('.pswp__button--print').on('click touchstart', function (e) {
         e.preventDefault();
+        e.stopPropagation();
 
         const img = gallery.currItem.src.split('/').pop();
 
@@ -165,8 +167,9 @@ function initPhotoSwipeFromDOM (gallerySelector) {
     });
 
     // chroma keying print
-    $('.pswp__button--print-chroma-keying').on('click', function (e) {
+    $('.pswp__button--print-chroma-keying').on('click touchstart', function (e) {
         e.preventDefault();
+        e.stopPropagation();
 
         const img = gallery.currItem.src.split('/').pop();
 


### PR DESCRIPTION
Fix https://github.com/andreknieriem/photobooth/issues/185 &  https://github.com/andreknieriem/photobooth/issues/116

From what i found out:
> The problem with .click on iOS is that it unbinds the click event."
> 

> (...) using 'click touchstart' will get the desired result. If you console.log(e) your clicks though, you may find that when jquery recognizes touch as a click - you will get 2 actions from click and touchstart.
>

Good read about the problem having 2 actions from click and touchstart: https://stackoverflow.com/questions/7018919/how-to-bind-touchstart-and-click-events-but-not-respond-to-both/36452427#36452427