### PR TITLE
Display collage count before taking photo

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -68,14 +68,17 @@ require_once('../lib/configsetup.inc.php');
 								case 'input':
 									echo '<label data-l10n="'.$panel.'_'.$key.'">'.$panel.'_'.$key.'</label><input type="text" name="'.$field['name'].'" value="'.$field[
 										'value'].'" placeholder="'.$field['placeholder'].'"/>';
-								break;
+									break;
+								case 'hidden':
+									echo '<input type="hidden" name="'.$field['name'].'" value="'.$field['value'].'"/>';
+									break;
 								case 'checkbox':
 									$checked = '';
 									if ($field['value'] == 'true') {
 										$checked = ' checked="checked"';
 									}
 									echo '<label><input type="checkbox" '.$checked.' name="'.$field['name'].'" value="true"/><span data-l10n="'.$key.'">'.$key.'</span></label>';
-								break;
+									break;
 								case 'multi-select':
 								case 'select':
 									$selectTag = '<select name="'.$field['name'] . ($field['type'] === 'multi-select' ? '[]' : '') . '"' . ($field['type'] === 'multi-select' ? ' multiple="multiple" size="10"' : '') . '>';
@@ -88,7 +91,7 @@ require_once('../lib/configsetup.inc.php');
 											echo '<option '.$selected.' value="'.$val.'">'.$option.'</option>';
 										}
 									echo '</select>';
-								break;
+									break;
 							}
 							echo '</div>';
 						}

--- a/api/takePic.php
+++ b/api/takePic.php
@@ -68,7 +68,7 @@ if ($_POST['style'] === 'photo') {
 
     if ($number > 3) {
         die(json_encode([
-            'error' => 'Collage consists only of 4 pictures',
+            'error' => 'Collage consists only of ' . $config['collage_limit'] . ' pictures',
         ]));
     }
 
@@ -81,7 +81,7 @@ if ($_POST['style'] === 'photo') {
         'success' => 'collage',
         'file' => $file,
         'current' => $number,
-        'limit' => 4,
+        'limit' => $config['collage_limit'],
     ]));
 } else {
     die(json_encode([

--- a/lib/config.php
+++ b/lib/config.php
@@ -70,6 +70,8 @@ $config['print']['cmd'] = $cmds[$os]['print']['cmd'];
 $config['print']['msg'] = $cmds[$os]['print']['msg'];
 $config['colors'] = $colors['default'];
 
+$config['collage_limit'] = 4;
+
 $defaultConfig = $config;
 
 if (file_exists($my_config_file)) {

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -75,6 +75,11 @@ $configsetup = [
 			'placeholder' => '',
 			'value' => $config['collage_key']
 		],
+		'collage_limit' => [
+			'type' => 'hidden',
+			'name' => 'collage_limit',
+			'value' => $config['collage_limit']
+		],
 		'force_buzzer' => [
 			'type' => 'checkbox',
 			'name' => 'force_buzzer',

--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -154,6 +154,7 @@ const photoBooth = (function () {
             $('.loading').text(L10N.cheese);
         } else {
             $('.loading').text(L10N.cheeseCollage);
+            $('<p>').text(`${nextCollageNumber + 1} / ${config.collage_limit}`).appendTo('.loading');
         }
 
         setTimeout(() => {
@@ -192,7 +193,6 @@ const photoBooth = (function () {
 
                 $('.spinner').hide();
                 $('.loading').empty();
-                $('<p>').text(`${result.current + 1} / ${result.limit}`).appendTo('.loading');
 
                 if (config.continuous_collage) {
                     setTimeout(() => {


### PR DESCRIPTION
**Current behaviour**:

- `L10N.cheeseCollage` is shown ('Cheeeeeeeese Collageeeeeeeeeee!')
- Picture is taken
- '1/4' is displayed
- `L10N.cheeseCollage` is shown
- Picture is taken
- '2/4' is displayed
- `L10N.cheeseCollage` is shown
- Picture is taken
- '3/4' is displayed
- `L10N.cheeseCollage` is shown
- Picture is taken
- Picture gets processed
- Where is "4/4"?

**Improvement**:

I find this quite counterintuitive and suggest the following change which displays the photo # **before** the picture is taken, so it's like: '1/4' - Pic - '2/4' - Pic ... '4/4' - Pic

- `L10N.cheeseCollage` + "1/4" is shown
- Picture is taken
- `L10N.cheeseCollage` + "2/4" is shown
- Picture is taken
- `L10N.cheeseCollage` + "3/4" is shown
- Picture is taken
- `L10N.cheeseCollage` + "**4/4**" is shown
- Picture is taken
- Picture gets processed

