### PR TITLE
Device cam and styling fixes

### DIFF
--- a/api/admin.php
+++ b/api/admin.php
@@ -94,6 +94,10 @@ if ($data['type'] == 'config') {
         $newConfig['login_password'] = NULL;
     }
 
+    if (!$newConfig['previewFromCam']) {
+        $newConfig['previewCamTakesPic'] = false;
+    }
+
     $content = "<?php\n\$config = ". var_export(arrayRecursiveDiff($newConfig, $defaultConfig), true) . ";";
 
     if (file_put_contents($my_config_file, $content)) {

--- a/api/takePic.php
+++ b/api/takePic.php
@@ -14,7 +14,7 @@ function takePicture($filename)
             $demoFolder . $devImg[array_rand($devImg)],
             $filename
         );
-    } elseif ($config['previewCamTakesPic']) {
+    } elseif ($config['previewFromCam'] && $config['previewCamTakesPic']) {
         $data = $_POST['canvasimg'];
         list($type, $data) = explode(';', $data);
         list(, $data)      = explode(',', $data);

--- a/index.php
+++ b/index.php
@@ -126,9 +126,7 @@ $imagelist = ($config['newest_first'] === true) ? array_reverse($images) : $imag
 					<i class="fa fa-cog fa-spin"></i>
 				</div>
 
-				<?php if ($config['previewFromCam']): ?>
 				<video id="video--view" autoplay playsinline></video>
-				<?php endif; ?>
 
 				<div id="counter">
 					<canvas id="video--sensor"</canvas>

--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -164,9 +164,18 @@ const photoBooth = (function () {
             $('<p>').text(`${nextCollageNumber + 1} / ${config.collage_limit}`).appendTo('.cheese');
         }
 
-        setTimeout(() => {
-            public.takePic(photoStyle);
-        }, config.cheese_time);
+        if (config.previewFromCam && config.previewCamTakesPic && !public.stream && !config.dev) {
+            console.log('No preview by device cam available!');
+
+            public.errorPic({
+                error: 'No preview by device cam available!'
+            });
+
+        } else {
+            setTimeout(() => {
+                public.takePic(photoStyle);
+            }, config.cheese_time);
+        }
     }
 
     // take Picture

--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -247,6 +247,7 @@ const photoBooth = (function () {
             $('.spinner').hide();
             $('.loading').empty();
             $('.cheese').empty();
+            $('#video--view').hide();
             $('#video--sensor').hide();
             loader.addClass('error');
             $('.loading').append($('<p>').text(L10N.error));

--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -71,6 +71,8 @@ const photoBooth = (function () {
         gallery.find('.gallery__inner').hide();
         $('.spinner').hide();
         $('.send-mail').hide();
+        $('#video--view').hide();
+        $('#video--sensor').hide();
         public.resetMailForm();
     }
 

--- a/resources/sass/style.scss
+++ b/resources/sass/style.scss
@@ -212,6 +212,10 @@ input[type="email"] {
   p {
     margin: 0 0 0.2em;
   }
+
+  .btn {
+    font-size: 0.4em;
+  }
 }
 
 .error {


### PR DESCRIPTION
- Hide video--view on error, else no access to reload button on error page

- we can only use the device cam to take pictures if we use preview by device cam, therefore disable take pic by device cam config if preview by device cam is not enabled

- we can only take a pic using device cam if we have a preview, abort with an error if there's no preview (e.g. because camera access was denied or because no device cam is abvailable)

- also fix button font size on error page and collage
