### PR TITLE
Improved width of admin panel

### DIFF
--- a/resources/sass/admin.scss
+++ b/resources/sass/admin.scss
@@ -37,7 +37,7 @@ input[type="checkbox"] {
 }
 
 .admin-panel {
-  width: 500px;
+  width: calc(31.25 * 1em);
   padding: 30px 30px 90px;
   height: auto;
   margin: 50px auto;


### PR DESCRIPTION
Using larger font size makes the admin panel looks bad. Width of admin panel now depends on font size. The constant is default width / default font size: 500px/16px = 31.25