### PR TITLE
Option to allow/disallow the user to delete the image

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -31,6 +31,7 @@ $config['cheese_time'] = '1000'; // control time for cheeeeese!
 $config['use_filter'] = true;
 $config['default_imagefilter'] = 'plain';
 $config['disabled_filters'] = array();
+$config['allow_delete'] = true;
 $config['polaroid_effect'] = false;
 $config['polaroid_rotation'] = '0';
 $config['take_frame'] = false;

--- a/index.php
+++ b/index.php
@@ -171,7 +171,9 @@ $imagelist = ($config['newest_first'] === true) ? array_reverse($images) : $imag
 				<a href="#" class="btn imageFilter"><i class="fa fa-magic"></i> <span data-l10n="selectFilter"></span></a>
 				<?php endif; ?>
 
+				<?php if ($config['allow_delete']): ?>
 				<a href="#" class="btn deletebtn"><i class="fa fa-trash"></i> <span data-l10n="delete"></span></a>
+				<?php endif; ?>
 			</div>
 
 			<?php if ($config['use_qr']): ?>

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -200,6 +200,11 @@ $configsetup = [
 				'environment' => 'Back facing camera'
 			],
 			'value' => $config['camera_mode']
+		],
+		'allow_delete' => [
+			'type' => 'checkbox',
+			'name' => 'allow_delete',
+			'value' => $config['allow_delete']
 		]
 	],
 	'jpeg_quality' => [

--- a/resources/lang/de.js
+++ b/resources/lang/de.js
@@ -12,6 +12,7 @@ const L10N = {
     'general_default_imagefilter': 'Standardbildfilter',
     'default_imagefilter': 'Bildfilter auswählen',
     'general_disabled_filters': 'Deaktivierte Bildfilter',
+    'allow_delete': 'Löschen des Bildes erlauben',
     'general_collage_cntdwn_time': 'Collage-Countdown Timer in Sekunden',
     'continuous_collage': 'Collage ohne Unterbrechung aufnehmen',
     'delete': 'Löschen',

--- a/resources/lang/en.js
+++ b/resources/lang/en.js
@@ -12,6 +12,7 @@ const L10N = {
     'general_default_imagefilter': 'Default image filter',
     'default_imagefilter': 'Choose image filter',
     'general_disabled_filters': 'Disabled image filters',
+    'allow_delete': 'Allow deletion of the image',
     'general_collage_cntdwn_time': 'Collage-countdown timer in seconds',
     'continuous_collage': 'Take collage without interruption',
     'delete': 'Delete',

--- a/resources/lang/es.js
+++ b/resources/lang/es.js
@@ -12,6 +12,7 @@ const L10N = {
     'general_default_imagefilter': 'Filtro de imagen predeterminado',
     'default_imagefilter': 'Elegir filtro de imagen',
     'general_disabled_filters': 'Filtros deshabilitados',
+    'allow_delete': 'Permitir la eliminación de la imagen',
     'general_collage_cntdwn_time': 'Cuenta regresiva del collage en segundos',
     'continuous_collage': 'Toma collage sin interrupción',
     'delete': 'Eliminar',

--- a/resources/lang/fr.js
+++ b/resources/lang/fr.js
@@ -12,6 +12,7 @@ const L10N = {
     'general_default_imagefilter': 'Filtre d\'image par défaut',
     'default_imagefilter': 'Choisissez le filtre d\'image',
     'general_disabled_filters': 'Filtres désactivés',
+    'allow_delete': 'Autoriser la suppression de l\'image',
     'general_collage_cntdwn_time': 'Montage photo compte à rebours en secondes',
     'continuous_collage': 'Prendre un photo montage sans interruption',
     'delete': 'Effacer',

--- a/resources/lang/gr.js
+++ b/resources/lang/gr.js
@@ -12,6 +12,7 @@ const L10N = {
     'general_default_imagefilter': 'Προεπιλεγμένο φίλτρο εικόνας',
     'default_imagefilter': 'Επιλέξτε φίλτρο εικόνας',
     'general_disabled_filters': 'Απενεργοποιημένα φίλτρα',
+    'allow_delete': 'Επιτρέψτε τη διαγραφή της εικόνας',
     'general_collage_cntdwn_time': 'Χρονοδιακόπτης αντίστροφης μέτρησης φωτογραφιών σε δευτερόλεπτα',
     'continuous_collage': 'Εγγραφή κολάζ χωρίς διακοπή',
     'delete': 'διαγραφή',


### PR DESCRIPTION
Thank you for the awesome photobooth software! We had a lot of fun on our last wedding.

We hadsome people on the wedding, who trying to take a perfect photo. They took a picture and delete it. Several times... So I created this pull request to disable/allow the deletion of an image.

I added a option:
![Settings](https://user-images.githubusercontent.com/695449/75336411-649e0f00-588b-11ea-9dae-c045ec3b7bcf.JPG)

![Ja](https://user-images.githubusercontent.com/695449/75336445-72ec2b00-588b-11ea-9883-0a110374fc09.JPG)
![Nein](https://user-images.githubusercontent.com/695449/75336449-74b5ee80-588b-11ea-8f59-13fcc35b2e8c.JPG)

